### PR TITLE
Refactored duel arena references.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
     mavenCentral()
 }
 
-def runeLiteVersion = '1.8.18.4'
+def runeLiteVersion = '1.8.27'
 
 dependencies {
     compileOnly group: 'net.runelite', name: 'client', version: runeLiteVersion
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.larsvansoest.runelite'
-version = '4.0.1'
+version = '4.0.2'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/larsvansoest/runelite/clueitems/EmoteClueItemsPlugin.java
+++ b/src/main/java/com/larsvansoest/runelite/clueitems/EmoteClueItemsPlugin.java
@@ -106,7 +106,7 @@ public class EmoteClueItemsPlugin extends Plugin
 				this.itemManager,
 				this::onStashUnitFilledChanged,
 				"Emote Clue Items",
-				"v4.0.1",
+				"v4.0.2",
 				"https://github.com/larsvansoest/emote-clue-items"
 		);
 

--- a/src/main/java/com/larsvansoest/runelite/clueitems/data/EmoteClue.java
+++ b/src/main/java/com/larsvansoest/runelite/clueitems/data/EmoteClue.java
@@ -51,7 +51,7 @@ import static net.runelite.client.plugins.cluescrolls.clues.item.ItemRequirement
  * Source: https://github.com/runelite/runelite/tree/master/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues
  * </p>
  * <p>
- * Maintained up to af5ae4a.
+ * Maintained up to 91e5d18.
  * To check for any updates, see https://github.com/runelite/runelite/commits/master/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java
  * </p>
  *
@@ -302,9 +302,9 @@ public final class EmoteClue implements TextClueScroll, LocationClueScroll
 					EmoteClueItem.ANY_AMULET_OF_GLORY
 			),
 			new EmoteClue(Easy,
-					"Bow in the ticket office of the Duel Arena. Equip an iron chain body, leather chaps and coif.",
-					"Duel Arena",
-					MUBARIZS_ROOM_AT_THE_DUEL_ARENA,
+					"Bow in the ticket office of the PvP Arena. Equip an iron chain body, leather chaps and coif.",
+					"PvP Arena",
+					PVP_ARENA_TICKET_OFFICE,
 					new WorldPoint(3314, 3241, 0),
 					BOW,
 					EmoteClueItem.IRON_CHAINBODY,

--- a/src/main/java/com/larsvansoest/runelite/clueitems/data/StashUnit.java
+++ b/src/main/java/com/larsvansoest/runelite/clueitems/data/StashUnit.java
@@ -10,7 +10,7 @@ import net.runelite.client.plugins.cluescrolls.clues.emote.STASHUnit;
  * Source https://github.com/runelite/runelite/blob/master/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/emote/STASHUnit.java
  * </p>
  * <p>
- * Maintained up to b7cbdcdf
+ * Maintained up to 91e5d18.
  * </p>
  *
  * @author Lars van Soest
@@ -44,7 +44,7 @@ public enum StashUnit
 	ROAD_JUNCTION_SOUTH_OF_SINCLAIR_MANSION("Sinclaire Mansion Junction", STASHUnit.ROAD_JUNCTION_SOUTH_OF_SINCLAIR_MANSION, Type.Rock),
 	OUTSIDE_THE_DIGSITE_EXAM_CENTRE("Digsite Exam Centre", STASHUnit.OUTSIDE_THE_DIGSITE_EXAM_CENTRE, Type.Bush),
 	NEAR_THE_SAWMILL_OPERATORS_BOOTH("Sawmill Operators Booth", STASHUnit.NEAR_THE_SAWMILL_OPERATORS_BOOTH, Type.Bush),
-	MUBARIZS_ROOM_AT_THE_DUEL_ARENA("Duel Arena Mubariz's Room", STASHUnit.MUBARIZS_ROOM_AT_THE_DUEL_ARENA, Type.Crate),
+	PVP_ARENA_TICKET_OFFICE("PvP Arena Ticket Office", STASHUnit.PVP_ARENA_TICKET_OFFICE, Type.Crate),
 	OUTSIDE_VARROCK_PALACE_COURTYARD("Varrock Palace Courtyard", STASHUnit.OUTSIDE_VARROCK_PALACE_COURTYARD, Type.Bush),
 	NEAR_HERQUINS_SHOP_IN_FALADOR("Falador Herquins Shop", STASHUnit.NEAR_HERQUINS_SHOP_IN_FALADOR, Type.Bush),
 	SOUTH_OF_THE_GRAND_EXCHANGE("Varrock Grand Exchange", STASHUnit.SOUTH_OF_THE_GRAND_EXCHANGE, Type.Bush),


### PR DESCRIPTION
It appears that an enum value was renamed on the runelite API.

Resolves #70 