### PR TITLE
Updated broken imports after RuneLite update 1.9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Emote Clue Items v4.0.2 [![Plugin Installs](http://img.shields.io/endpoint?url=https://i.pluginhub.info/shields/installs/plugin/emote-clue-items&label=Active%20installs)](https://runelite.net/plugin-hub/Lars%20van%20Soest)
+## Emote Clue Items v4.0.3 [![Plugin Installs](http://img.shields.io/endpoint?url=https://i.pluginhub.info/shields/installs/plugin/emote-clue-items&label=Active%20installs)](https://runelite.net/plugin-hub/Lars%20van%20Soest)
 
 Emote Clue Items is a RuneLite plugin which highlights items required for emote clue steps and provides a user-friendly
 item collection log with STASHUnit integration.

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
     mavenCentral()
 }
 
-def runeLiteVersion = '1.8.27'
+def runeLiteVersion = '1.9.4'
 
 dependencies {
     compileOnly group: 'net.runelite', name: 'client', version: runeLiteVersion
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.larsvansoest.runelite'
-version = '4.0.2'
+version = '4.0.3'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/larsvansoest/runelite/clueitems/EmoteClueItemsPlugin.java
+++ b/src/main/java/com/larsvansoest/runelite/clueitems/EmoteClueItemsPlugin.java
@@ -106,7 +106,7 @@ public class EmoteClueItemsPlugin extends Plugin
 				this.itemManager,
 				this::onStashUnitFilledChanged,
 				"Emote Clue Items",
-				"v4.0.2",
+				"v4.0.3",
 				"https://github.com/larsvansoest/emote-clue-items"
 		);
 

--- a/src/main/java/com/larsvansoest/runelite/clueitems/data/EmoteClue.java
+++ b/src/main/java/com/larsvansoest/runelite/clueitems/data/EmoteClue.java
@@ -32,7 +32,6 @@ import net.runelite.api.annotations.Varbit;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.plugins.cluescrolls.clues.Enemy;
 import net.runelite.client.plugins.cluescrolls.clues.LocationClueScroll;
-import net.runelite.client.plugins.cluescrolls.clues.TextClueScroll;
 import net.runelite.client.plugins.cluescrolls.clues.emote.Emote;
 import net.runelite.client.plugins.cluescrolls.clues.item.ItemRequirement;
 
@@ -51,7 +50,7 @@ import static net.runelite.client.plugins.cluescrolls.clues.item.ItemRequirement
  * Source: https://github.com/runelite/runelite/tree/master/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues
  * </p>
  * <p>
- * Maintained up to 91e5d18.
+ * Maintained up to 3e65e49.
  * To check for any updates, see https://github.com/runelite/runelite/commits/master/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java
  * </p>
  *
@@ -59,7 +58,7 @@ import static net.runelite.client.plugins.cluescrolls.clues.item.ItemRequirement
  */
 @SuppressWarnings("SameParameterValue")
 @Getter
-public final class EmoteClue implements TextClueScroll, LocationClueScroll
+public final class EmoteClue implements LocationClueScroll
 {
 	public static final Set<EmoteClue> CLUES = ImmutableSet.of(
 			new EmoteClue(

--- a/src/main/java/com/larsvansoest/runelite/clueitems/data/EmoteClueItem.java
+++ b/src/main/java/com/larsvansoest/runelite/clueitems/data/EmoteClueItem.java
@@ -167,7 +167,7 @@ public enum EmoteClueItem implements ItemRequirement
 	BRUISE_BLUE_SNELM_POINTED("Bruise blue snelm (pointed)", ItemID.BRUISE_BLUE_SNELM_3343),
 	BRYOPHYTAS_STAFF_UNCHARGED("Bryophytas' staff (uncharged)", ItemID.BRYOPHYTAS_STAFF_UNCHARGED),
 	BRYOPHYTAS_STAFF("Bryophytas' staff", ItemID.BRYOPHYTAS_STAFF),
-	BULL_ROARER("Bull roarer", ItemID.BULL_ROARER),
+	BULL_ROARER("Bull roarer", ItemID.BULLROARER),
 	CAPE_OF_LEGENDS("Cape of legends", ItemID.CAPE_OF_LEGENDS),
 	CASTLE_WARS_BRACELET1("Castle wars bracelet1", ItemID.CASTLE_WARS_BRACELET1),
 	CASTLE_WARS_BRACELET2("Castle wars bracelet2", ItemID.CASTLE_WARS_BRACELET2),


### PR DESCRIPTION
Fixes #76.

RuneLite update 1.9.4. broke a few imports. This should fix the issues and let the plugin build correctly again. As a result, it should show up on the plugin hub again.