### PR TITLE
Fix ref to Bruise blue snelm (pointed)

### DIFF
--- a/src/main/java/com/larsvansoest/runelite/clueitems/data/EmoteClueItem.java
+++ b/src/main/java/com/larsvansoest/runelite/clueitems/data/EmoteClueItem.java
@@ -192,7 +192,7 @@ public enum EmoteClueItem implements ItemRequirement
 	BRONZE_SQ_SHIELD("Bronze sq shield", ItemID.BRONZE_SQ_SHIELD),
 	BROWN_APRON("Brown apron", ItemID.BROWN_APRON),
 	BROWN_HEADBAND("Brown headband", ItemID.BROWN_HEADBAND),
-	BRUISE_BLUE_SNELM_POINTED("Bruise blue snelm (pointed)", ItemID.BRUISE_BLUE_SNELM),
+	BRUISE_BLUE_SNELM_POINTED("Bruise blue snelm (pointed)", ItemID.POINTED_BRUISE_BLUE_SNELM ),
 	BRYOPHYTAS_STAFF_UNCHARGED("Bryophytas' staff (uncharged)", ItemID.BRYOPHYTAS_STAFF_UNCHARGED),
 	BRYOPHYTAS_STAFF("Bryophytas' staff", ItemID.BRYOPHYTAS_STAFF),
 	BULL_ROARER("Bull roarer", ItemID.BULLROARER),


### PR DESCRIPTION
updated item id ref from BRUISE_BLUE_SNELM to POINTED_BRUISE_BLUE_SNELM  to accurately represent the poitned variant from rounded