### PR TITLE
fix(bank-rework): #134 - makes marking bank items work again after RuneScape ui update.

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/larsvansoest/runelite/clueitems/overlay/Widget.java
+++ b/src/main/java/com/larsvansoest/runelite/clueitems/overlay/Widget.java
@@ -33,9 +33,9 @@ package com.larsvansoest.runelite.clueitems.overlay;
  */
 public enum Widget
 {
-	BANK(12, 10),
+	BANK(12, 12),
 
-	BANK_EQUIPMENT(12, 69),
+	BANK_EQUIPMENT(12, 54),
 
 	BANK_EQUIPMENT_INVENTORY(15, 4),
 


### PR DESCRIPTION
Fixes #134 